### PR TITLE
Bump v8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v8.1.0 (2021-09-07)
+
+#### :rocket: Enhancement
+
+- `nestjs-firebase`, `nestjs-graphql-relay`, `nestjs-slack-webhook`, `nestjs-zendesk`
+  - [#905](https://github.com/g59/nestjs-plugins/pull/905) feat: export firebase admin storage ([@9renpoto](https://github.com/9renpoto))
+
+#### Committers: 1
+
+- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))
+
 ## v8.0.0 (2021-08-18)
 
 #### :rocket: Enhancement

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "private": true,
   "description": "nestjs-plugins examples",
   "license": "MIT",
@@ -21,10 +21,10 @@
     "@nestjs/config": "^1.0.0",
     "@nestjs/platform-express": "^8.0.6",
     "apollo-server-types": "^3.0.0",
-    "nestjs-firebase": "^8.0.0",
-    "nestjs-graphql-relay": "^8.0.0",
-    "nestjs-slack-webhook": "^8.0.0",
-    "nestjs-zendesk": "^8.0.0"
+    "nestjs-firebase": "^8.1.0",
+    "nestjs-graphql-relay": "^8.1.0",
+    "nestjs-slack-webhook": "^8.1.0",
+    "nestjs-zendesk": "^8.1.0"
   },
   "devDependencies": {
     "@nestjs/testing": "8.0.6",

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
   },
   "npmClient": "npm",
   "useWorkspaces": true,
-  "version": "8.0.0"
+  "version": "8.1.0"
 }

--- a/packages/nestjs-firebase/package.json
+++ b/packages/nestjs-firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-firebase",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "@nestjs with firebase",
   "license": "MIT",
   "homepage": "https://github.com/g59/nestjs-plugins/tree/main/packages/nestjs-firebase",

--- a/packages/nestjs-graphql-relay/package.json
+++ b/packages/nestjs-graphql-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-graphql-relay",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "@nestjs/graphql + graphql-relay + typeorm",
   "license": "MIT",
   "repository": {

--- a/packages/nestjs-slack-webhook/package.json
+++ b/packages/nestjs-slack-webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-slack-webhook",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Nest.js + slack-webhook",
   "license": "MIT",
   "repository": {

--- a/packages/nestjs-zendesk/package.json
+++ b/packages/nestjs-zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-zendesk",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## v8.1.0 (2021-09-07)

#### :rocket: Enhancement

- `nestjs-firebase`, `nestjs-graphql-relay`, `nestjs-slack-webhook`, `nestjs-zendesk`
  - [#905](https://github.com/g59/nestjs-plugins/pull/905) feat: export firebase admin storage ([@9renpoto](https://github.com/9renpoto))

#### Committers: 1

- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))