### PR TITLE
Bump v8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v8.1.0 (2021-09-17)
+
+#### :rocket: Enhancement
+
+- `nestjs-firebase`
+  - [#924](https://github.com/g59/nestjs-plugins/pull/924) chore: firebase AppOptions ([@9renpoto](https://github.com/9renpoto))
+- `nestjs-firebase`, `nestjs-graphql-relay`, `nestjs-slack-webhook`, `nestjs-zendesk`
+  - [#905](https://github.com/g59/nestjs-plugins/pull/905) feat: export firebase admin storage ([@9renpoto](https://github.com/9renpoto))
+
+#### Committers: 1
+
+- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))
+
 ## v8.0.0 (2021-08-18)
 
 #### :rocket: Enhancement

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "private": true,
   "description": "nestjs-plugins examples",
   "license": "MIT",
@@ -20,11 +20,7 @@
     "@nestjs/cli": "^8.0.2",
     "@nestjs/config": "^1.0.0",
     "@nestjs/platform-express": "^8.0.6",
-    "apollo-server-types": "^3.0.0",
-    "nestjs-firebase": "^8.0.0",
-    "nestjs-graphql-relay": "^8.0.0",
-    "nestjs-slack-webhook": "^8.0.0",
-    "nestjs-zendesk": "^8.0.0"
+    "apollo-server-types": "^3.0.0"
   },
   "devDependencies": {
     "@nestjs/testing": "8.0.6",

--- a/example/package.json
+++ b/example/package.json
@@ -20,7 +20,11 @@
     "@nestjs/cli": "^8.0.2",
     "@nestjs/config": "^1.0.0",
     "@nestjs/platform-express": "^8.0.6",
-    "apollo-server-types": "^3.0.0"
+    "apollo-server-types": "^3.0.0",
+    "nestjs-firebase": "^8.0.0",
+    "nestjs-graphql-relay": "^8.0.0",
+    "nestjs-slack-webhook": "^8.0.0",
+    "nestjs-zendesk": "^8.0.0"
   },
   "devDependencies": {
     "@nestjs/testing": "8.0.6",

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
   },
   "npmClient": "npm",
   "useWorkspaces": true,
-  "version": "8.0.0"
+  "version": "8.1.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10600,9 +10600,9 @@
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
     },
     "node_modules/graphql": {
-      "version": "15.5.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
-      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
+      "version": "15.5.3",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.3.tgz",
+      "integrity": "sha512-sM+jXaO5KinTui6lbK/7b7H/Knj9BpjGxZ+Ki35v7YbUJxxdBCUqNM0h3CRVU1ZF9t5lNiBzvBCSYPvIwxPOQA==",
       "peer": true,
       "engines": {
         "node": ">= 10.x"
@@ -10626,15 +10626,15 @@
       }
     },
     "node_modules/graphql-relay": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.8.0.tgz",
-      "integrity": "sha512-NU7CkwNxPzkqpBgv76Cgycrc3wmWVA2K5Sxm9DHSSLLuQTpaSRAUsX1sf2gITf+XQpkccsv56/z0LojXTyQbUw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.9.0.tgz",
+      "integrity": "sha512-yNJLCqcjz0XpzpmmckRJCSK8a2ZLwTurwrQ09UyGftONh52PbrGpK1UO4yspvj0c7pC+jkN4ZUqVXG3LRrWkXQ==",
       "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.15.0 || >= 15.9.0"
       },
       "peerDependencies": {
-        "graphql": "15.5.1"
+        "graphql": "^15.5.3"
       }
     },
     "node_modules/graphql-subscriptions": {
@@ -22150,10 +22150,10 @@
         "typeorm-factory": "0.0.14"
       },
       "peerDependencies": {
-        "@apollo/gateway": "^0.33.0 || ^0.38.0 || ^0.39.0 || ^0.40.0 || ^0.41.0",
+        "@apollo/gateway": "^0.33.0 || ^0.41.0",
         "@nestjs/graphql": "^8.0.0 || ^9.0.0",
         "@nestjs/typeorm": "^8.0.0",
-        "graphql-relay": "^0.8.0 || ^0.9.0"
+        "graphql-relay": "^0.9.0"
       }
     },
     "packages/nestjs-graphql-relay/node_modules/@ts-morph/common": {
@@ -30720,9 +30720,9 @@
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
     },
     "graphql": {
-      "version": "15.5.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
-      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
+      "version": "15.5.3",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.3.tgz",
+      "integrity": "sha512-sM+jXaO5KinTui6lbK/7b7H/Knj9BpjGxZ+Ki35v7YbUJxxdBCUqNM0h3CRVU1ZF9t5lNiBzvBCSYPvIwxPOQA==",
       "peer": true
     },
     "graphql-extensions": {
@@ -30736,9 +30736,9 @@
       }
     },
     "graphql-relay": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.8.0.tgz",
-      "integrity": "sha512-NU7CkwNxPzkqpBgv76Cgycrc3wmWVA2K5Sxm9DHSSLLuQTpaSRAUsX1sf2gITf+XQpkccsv56/z0LojXTyQbUw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.9.0.tgz",
+      "integrity": "sha512-yNJLCqcjz0XpzpmmckRJCSK8a2ZLwTurwrQ09UyGftONh52PbrGpK1UO4yspvj0c7pC+jkN4ZUqVXG3LRrWkXQ==",
       "peer": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,17 +40,13 @@
       }
     },
     "example": {
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cli": "^8.0.2",
         "@nestjs/config": "^1.0.0",
         "@nestjs/platform-express": "^8.0.6",
-        "apollo-server-types": "^3.0.0",
-        "nestjs-firebase": "^8.0.0",
-        "nestjs-graphql-relay": "^8.0.0",
-        "nestjs-slack-webhook": "^8.0.0",
-        "nestjs-zendesk": "^8.0.0"
+        "apollo-server-types": "^3.0.0"
       },
       "devDependencies": {
         "@nestjs/testing": "8.0.6",
@@ -22134,7 +22130,7 @@
       }
     },
     "packages/nestjs-firebase": {
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "devDependencies": {
         "@google-cloud/firestore": "4.15.1",
@@ -22146,7 +22142,7 @@
       }
     },
     "packages/nestjs-graphql-relay": {
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "devDependencies": {
         "sqlite3": "5.0.2",
@@ -22183,7 +22179,7 @@
       }
     },
     "packages/nestjs-slack-webhook": {
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "devDependencies": {
         "@nestjs/testing": "8.0.6"
@@ -22194,7 +22190,7 @@
       }
     },
     "packages/nestjs-zendesk": {
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node-zendesk": "2.0.3"
@@ -29512,10 +29508,6 @@
         "@types/node": "16.9.2",
         "@types/supertest": "2.0.11",
         "apollo-server-types": "^3.0.0",
-        "nestjs-firebase": "^8.0.0",
-        "nestjs-graphql-relay": "^8.0.0",
-        "nestjs-slack-webhook": "^8.0.0",
-        "nestjs-zendesk": "^8.0.0",
         "supertest": "6.1.6",
         "ts-loader": "9.2.5",
         "tsconfig-paths": "3.11.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,11 @@
         "@nestjs/cli": "^8.0.2",
         "@nestjs/config": "^1.0.0",
         "@nestjs/platform-express": "^8.0.6",
-        "apollo-server-types": "^3.0.0"
+        "apollo-server-types": "^3.0.0",
+        "nestjs-firebase": "^8.0.0",
+        "nestjs-graphql-relay": "^8.0.0",
+        "nestjs-slack-webhook": "^8.0.0",
+        "nestjs-zendesk": "^8.0.0"
       },
       "devDependencies": {
         "@nestjs/testing": "8.0.6",
@@ -29508,6 +29512,10 @@
         "@types/node": "16.9.2",
         "@types/supertest": "2.0.11",
         "apollo-server-types": "^3.0.0",
+        "nestjs-firebase": "^8.0.0",
+        "nestjs-graphql-relay": "^8.0.0",
+        "nestjs-slack-webhook": "^8.0.0",
+        "nestjs-zendesk": "^8.0.0",
         "supertest": "6.1.6",
         "ts-loader": "9.2.5",
         "tsconfig-paths": "3.11.0"

--- a/packages/nestjs-firebase/package.json
+++ b/packages/nestjs-firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-firebase",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "@nestjs with firebase",
   "license": "MIT",
   "homepage": "https://github.com/g59/nestjs-plugins/tree/main/packages/nestjs-firebase",

--- a/packages/nestjs-graphql-relay/package.json
+++ b/packages/nestjs-graphql-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-graphql-relay",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "@nestjs/graphql + graphql-relay + typeorm",
   "license": "MIT",
   "repository": {

--- a/packages/nestjs-graphql-relay/package.json
+++ b/packages/nestjs-graphql-relay/package.json
@@ -23,10 +23,10 @@
     "typeorm"
   ],
   "peerDependencies": {
-    "@apollo/gateway": "^0.33.0 || ^0.38.0 || ^0.39.0 || ^0.40.0 || ^0.41.0",
+    "@apollo/gateway": "^0.33.0 || ^0.41.0",
     "@nestjs/graphql": "^8.0.0 || ^9.0.0",
     "@nestjs/typeorm": "^8.0.0",
-    "graphql-relay": "^0.8.0 || ^0.9.0"
+    "graphql-relay": "^0.9.0"
   },
   "devDependencies": {
     "sqlite3": "5.0.2",

--- a/packages/nestjs-slack-webhook/package.json
+++ b/packages/nestjs-slack-webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-slack-webhook",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Nest.js + slack-webhook",
   "license": "MIT",
   "repository": {

--- a/packages/nestjs-zendesk/package.json
+++ b/packages/nestjs-zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-zendesk",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## v8.1.0 (2021-09-17)

#### :rocket: Enhancement

- `nestjs-firebase`
  - [#924](https://github.com/g59/nestjs-plugins/pull/924) chore: firebase AppOptions ([@9renpoto](https://github.com/9renpoto))
- `nestjs-firebase`, `nestjs-graphql-relay`, `nestjs-slack-webhook`, `nestjs-zendesk`
  - [#905](https://github.com/g59/nestjs-plugins/pull/905) feat: export firebase admin storage ([@9renpoto](https://github.com/9renpoto))

#### Committers: 1

- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))