### PR TITLE
Allow no credential to initialize from GCP environment defaults

### DIFF
--- a/packages/nestjs-firebase/__tests__/getFirebaseAdmin.test.ts
+++ b/packages/nestjs-firebase/__tests__/getFirebaseAdmin.test.ts
@@ -1,12 +1,10 @@
-
-import { getFirebaseAdmin } from "../src/util/getFirebaseAdmin"
-
+import { getFirebaseAdmin } from "../src/util/getFirebaseAdmin";
 
 describe("getFirebaseAdmin", () => {
-    it("returns firebase admin client", () => {
-        const  firebase = getFirebaseAdmin({
-            googleApplicationCredential: undefined
-        });
-        expect(firebase).toBeTruthy();
-    })
+  it("returns firebase admin client", () => {
+    const firebase = getFirebaseAdmin({
+      googleApplicationCredential: undefined,
+    });
+    expect(firebase).toBeTruthy();
+  });
 });

--- a/packages/nestjs-firebase/__tests__/getFirebaseAdmin.test.ts
+++ b/packages/nestjs-firebase/__tests__/getFirebaseAdmin.test.ts
@@ -1,0 +1,12 @@
+
+import { getFirebaseAdmin } from "../src/util/getFirebaseAdmin"
+
+
+describe("getFirebaseAdmin", () => {
+    it("returns firebase admin client", () => {
+        const  firebase = getFirebaseAdmin({
+            googleApplicationCredential: undefined
+        });
+        expect(firebase).toBeTruthy();
+    })
+});

--- a/packages/nestjs-firebase/src/util/getFirebaseAdmin.ts
+++ b/packages/nestjs-firebase/src/util/getFirebaseAdmin.ts
@@ -1,6 +1,6 @@
-import * as firebaseAdmin from 'firebase-admin';
-import { AppOptions } from 'firebase-admin';
-import { FirebaseAdmin, FirebaseModuleOptions } from '../firebase.interface';
+import * as firebaseAdmin from "firebase-admin";
+import { AppOptions } from "firebase-admin";
+import { FirebaseAdmin, FirebaseModuleOptions } from "../firebase.interface";
 
 export const getFirebaseAdmin = ({
   googleApplicationCredential: serviceAccountPath,
@@ -14,7 +14,7 @@ export const getFirebaseAdmin = ({
   const isOptionsNotEmpty = Object.keys(options).length > 0;
 
   const app = firebaseAdmin.initializeApp(
-    isOptionsNotEmpty ? firebaseAdminOptions : undefined,
+    isOptionsNotEmpty ? firebaseAdminOptions : undefined
   );
 
   return {

--- a/packages/nestjs-firebase/src/util/getFirebaseAdmin.ts
+++ b/packages/nestjs-firebase/src/util/getFirebaseAdmin.ts
@@ -1,16 +1,21 @@
-import * as firebaseAdmin from "firebase-admin";
-import { FirebaseAdmin, FirebaseModuleOptions } from "../firebase.interface";
+import * as firebaseAdmin from 'firebase-admin';
+import { AppOptions } from 'firebase-admin';
+import { FirebaseAdmin, FirebaseModuleOptions } from '../firebase.interface';
 
 export const getFirebaseAdmin = ({
   googleApplicationCredential: serviceAccountPath,
   ...options
 }: FirebaseModuleOptions): FirebaseAdmin => {
-  const app = firebaseAdmin.initializeApp({
-    credential: serviceAccountPath
-      ? firebaseAdmin.credential.cert(serviceAccountPath)
-      : undefined,
-    ...options,
-  });
+  const firebaseAdminOptions: AppOptions = options || {};
+  if (serviceAccountPath) {
+    firebaseAdminOptions.credential =
+      firebaseAdmin.credential.cert(serviceAccountPath);
+  }
+  const isOptionsNotEmpty = Object.keys(options).length > 0;
+
+  const app = firebaseAdmin.initializeApp(
+    isOptionsNotEmpty ? firebaseAdminOptions : undefined,
+  );
 
   return {
     auth: app.auth(),

--- a/packages/nestjs-firebase/src/util/getFirebaseAdmin.ts
+++ b/packages/nestjs-firebase/src/util/getFirebaseAdmin.ts
@@ -11,7 +11,7 @@ export const getFirebaseAdmin = ({
     firebaseAdminOptions.credential =
       firebaseAdmin.credential.cert(serviceAccountPath);
   }
-  const isOptionsNotEmpty = Object.keys(options).length > 0;
+  const isOptionsNotEmpty = Object.keys(firebaseAdminOptions).length > 0;
 
   const app = firebaseAdmin.initializeApp(
     isOptionsNotEmpty ? firebaseAdminOptions : undefined


### PR DESCRIPTION
I found the `nestjs-firebase` module really helpful. I ran into some issues when deploying to my GCP environment.  When running without providing a credential I was getting an error complaining that no credential was provided (makes sense). I tracked this down to the `initializeApp` method. Since field `credential: undefined` was being passed in the options the firebase admin SDK didn't like that. If we passed undefined (or no object) to the `initializeApp` method it would default to load the credentials provided by the GCP environment instead of erroring. 

The reason I like the no credentials option is it keeps from needing to managing and providing a specific key file in deployed environments. 

Reference:
* https://firebase.google.com/docs/admin/setup#initialize-without-parameters
* https://github.com/firebase/firebase-admin-node/blob/9ab37f5d6ed6e03307869a3d46ef855b65666047/src/app/lifecycle.ts#L33

This PR  checks to see if no options were provided and pass options as undefined. Let me know if I can answer any questions. 