### PR TITLE
chore: firebase ability to use Realtime Database

### DIFF
--- a/packages/nestjs-firebase/src/firebase.interface.ts
+++ b/packages/nestjs-firebase/src/firebase.interface.ts
@@ -26,5 +26,6 @@ export interface FirebaseAdmin {
   auth: firebaseAdmin.auth.Auth;
   messaging: firebaseAdmin.messaging.Messaging;
   db: firebaseAdmin.firestore.Firestore;
+  database: firebaseAdmin.database.Database;
   storage: firebaseAdmin.storage.Storage;
 }

--- a/packages/nestjs-firebase/src/util/getFirebaseAdmin.ts
+++ b/packages/nestjs-firebase/src/util/getFirebaseAdmin.ts
@@ -5,6 +5,7 @@ const createInstances = (app: admin.app.App): FirebaseAdmin => ({
   auth: app.auth(),
   messaging: app.messaging(),
   db: app.firestore(),
+  database: app.database(),
   storage: app.storage(),
 });
 


### PR DESCRIPTION
Hi! First time here,

## The problem:
No access to Realtime Database API from the Firebase Admin SDK in the NestJS App.

## The solution:
- Added `database` attribute to `FirebaseAdmin` interface
- Adjust `createInstances` function to fulfill new interface

## Notes:
- previously there is a `db` attribute that provides access to firestore (which is confused me..) 
- seems that there is confusion with `db` and `database` attributes now
- I guess to have API more consistent, probably better to rename `db` -> `firestore`. But it leads to breaking changes
Like:
```
firestore: firebaseAdmin.firestore.Firestore;
``` 

WDYT?