### PR TITLE
(feat): add remote config to nestjs firebase module

### DIFF
--- a/packages/nestjs-firebase/src/firebase.interface.ts
+++ b/packages/nestjs-firebase/src/firebase.interface.ts
@@ -27,4 +27,5 @@ export interface FirebaseAdmin {
   messaging: firebaseAdmin.messaging.Messaging;
   firestore: firebaseAdmin.firestore.Firestore;
   storage: firebaseAdmin.storage.Storage;
+  remoteConfig: firebaseAdmin.remoteConfig.RemoteConfig;
 }

--- a/packages/nestjs-firebase/src/util/getFirebaseAdmin.ts
+++ b/packages/nestjs-firebase/src/util/getFirebaseAdmin.ts
@@ -6,6 +6,7 @@ const createInstances = (app: admin.app.App): FirebaseAdmin => ({
   messaging: app.messaging(),
   firestore: app.firestore(),
   storage: app.storage(),
+  remoteConfig: app.remoteConfig(),
 });
 
 export const getFirebaseAdmin = (


### PR DESCRIPTION
## The Problem
We can't use the Firebase RemoteConfig API from the `nestjs-firebase` module.

### What was done?

- Implementation of the remote config to nestjs-firebase module.


