### PR TITLE
feat: allow firebase-admin v12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13214,7 +13214,7 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^10.0.0",
-        "firebase-admin": "^10.0.0 || ^11.0.0"
+        "firebase-admin": "^10.0.0 || ^11.0.0 || ^12.0.0"
       }
     },
     "packages/nestjs-graphql-relay": {

--- a/packages/nestjs-firebase/package.json
+++ b/packages/nestjs-firebase/package.json
@@ -16,7 +16,7 @@
   ],
   "peerDependencies": {
     "@nestjs/common": "^10.0.0",
-    "firebase-admin": "^10.0.0 || ^11.0.0"
+    "firebase-admin": "^10.0.0 || ^11.0.0 || ^12.0.0"
   },
   "devDependencies": {
     "@google-cloud/firestore": "^7.6.0",


### PR DESCRIPTION
Hi there,
as all of the prerequisites of the breaking changes of firebase-admin v12 are already handled in the project it should be no problem to update to v12.
Main benefit is that CVE-2023-36665 - protobufjs is now resolved because v12 uses a fixed version.