### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-packages.yml
+++ b/.github/workflows/npm-publish-packages.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/g59/nestjs-plugins/security/code-scanning/12](https://github.com/g59/nestjs-plugins/security/code-scanning/12)

**How to fix:**  
Add an explicit `permissions` block to the workflow to strictly limit the GITHUB_TOKEN's permissions.

**Details:**  
The job that publishes (publish-gpr) may require `contents: write` (if it pushes tags or creates release artifacts via the API using GITHUB_TOKEN, which, in this YAML, it does NOT appear to). Otherwise, both jobs only need `contents: read`. For absolute least privilege, the workflow should set `permissions: contents: read` at the workflow root to restrict all jobs, and then if a job ever requires more, additional permissions can be granted at the job level.

**What to change:**  
Insert
```yaml
permissions:
  contents: read
```
right after the `name:` field at the workflow top (after line 4).

**What is needed:**  
No new methods, imports, or definitions are required—just a new `permissions` block in the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
