### PR TITLE
fix: grant write access to bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -32,7 +32,7 @@ jobs:
       - name: generate new version and save to env variable
         id: get_version
         run: |
-          echo "NEW_VERSION=$(cat packages/nestjs-firebase/package.json | jq -r .version)" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION=$(cat packages/nestjs-firebase/package.json | jq -r .version)" >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   bump:
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     runs-on: ubuntu-slim
     steps:


### PR DESCRIPTION
## Summary
- grant the bump workflow contents write permission
- allow workflow_dispatch runs to call the release notes API successfully

## Context
The bump workflow was failing in the `Generate release notes` step with `403 Resource not accessible by integration` because the directly dispatched workflow only had `contents: read`.