### PR TITLE
fix: declare tslib as a runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15181,6 +15181,9 @@
     "packages/nestjs-firebase": {
       "version": "11.0.2",
       "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
       "devDependencies": {
         "@google-cloud/firestore": "^8.6.0",
         "@google-cloud/storage": "^7.21.0"
@@ -15193,6 +15196,9 @@
     "packages/nestjs-graphql-relay": {
       "version": "11.0.2",
       "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
       "devDependencies": {
         "@types/validator": "^13.15.10",
         "@types/ws": "^8.18.1",
@@ -15210,6 +15216,9 @@
     "packages/nestjs-slack-webhook": {
       "version": "11.0.2",
       "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
       "peerDependencies": {
         "@nestjs/common": "^11.0.0",
         "@slack/webhook": "^7.0.6"
@@ -15218,6 +15227,9 @@
     "packages/nestjs-zendesk": {
       "version": "11.0.2",
       "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
       "devDependencies": {
         "@nestjs/testing": "^11.1.28"
       },

--- a/packages/nestjs-firebase/package.json
+++ b/packages/nestjs-firebase/package.json
@@ -14,6 +14,9 @@
     "nest",
     "firebase"
   ],
+  "dependencies": {
+    "tslib": "2.8.1"
+  },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",
     "firebase-admin": "^13.4.0"

--- a/packages/nestjs-graphql-relay/package.json
+++ b/packages/nestjs-graphql-relay/package.json
@@ -22,6 +22,9 @@
     "graphql-relay",
     "typeorm"
   ],
+  "dependencies": {
+    "tslib": "2.8.1"
+  },
   "peerDependencies": {
     "@apollo/gateway": "^2.11.2",
     "@nestjs/graphql": "^13.1.0",

--- a/packages/nestjs-slack-webhook/package.json
+++ b/packages/nestjs-slack-webhook/package.json
@@ -21,6 +21,9 @@
     "nest",
     "slack-webhook"
   ],
+  "dependencies": {
+    "tslib": "2.8.1"
+  },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",
     "@slack/webhook": "^7.0.6"

--- a/packages/nestjs-zendesk/package.json
+++ b/packages/nestjs-zendesk/package.json
@@ -22,6 +22,9 @@
     "nest",
     "zendesk"
   ],
+  "dependencies": {
+    "tslib": "2.8.1"
+  },
   "peerDependencies": {
     "node-zendesk": "^6.0.1"
   },


### PR DESCRIPTION
## Summary

- declare `tslib@2.8.1` as a direct runtime dependency of all four published packages
- keep the version aligned with the official NestJS packages
- update the workspace lockfile

## Why

The repository compiles with `importHelpers: true`, so the published JavaScript imports helpers from `tslib` at runtime. Relying on a transitive dependency makes the packages fail under strictly isolated dependency layouts such as pnpm.

Declaring `tslib` directly ensures each published package can resolve the helpers it emits without requiring consumers to install an undeclared implementation dependency.

## Validation

- all four published package builds passed
- `npm pack --dry-run` passed for all four packages
- package manifests and workspace lockfile entries resolve `tslib` to `2.8.1`
- `git diff --check` passed
- the root workspace build reaches the example app, which still fails with the existing `TS5055` errors caused by files under `example/dist`

Closes #2019

_This PR was prepared with OpenAI Codex._
