### PR TITLE
chore(graphql-relay): remove redundant type dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4708,17 +4708,8 @@
       "version": "13.15.10",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
+      "peer": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -15043,8 +15034,6 @@
         "tslib": "2.8.1"
       },
       "devDependencies": {
-        "@types/validator": "^13.15.10",
-        "@types/ws": "^8.18.1",
         "sqlite3": "^5.1.7"
       },
       "peerDependencies": {

--- a/packages/nestjs-graphql-relay/package.json
+++ b/packages/nestjs-graphql-relay/package.json
@@ -34,8 +34,6 @@
     "class-validator": ">=0.14.2"
   },
   "devDependencies": {
-    "@types/validator": "^13.15.10",
-    "@types/ws": "^8.18.1",
     "sqlite3": "^5.1.7"
   },
   "types": "lib/index.d.ts"


### PR DESCRIPTION
## Summary

- Remove the direct @types/validator dev dependency because class-validator already provides it.
- Remove the unused @types/ws dev dependency.
- Refresh the lockfile so @types/ws is removed while @types/validator remains available transitively.

## Verification

- npm ci --ignore-scripts
- TypeScript check with ambient types restricted to Node
- npm run lint --workspaces
- npm run clean --workspaces && npm run build --workspaces
- SLACK_WEBHOOK_URL=https://example.com npm test -- --runInBand (26 suites, 42 tests)
- npm pack --dry-run --workspace nestjs-graphql-relay

No domain logic or public API behavior is changed.
