### PR TITLE
chore(test): centralize NestJS testing dependency

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -24,8 +24,5 @@
     "nestjs-graphql-relay": "11.0.0",
     "nestjs-slack-webhook": "11.0.0",
     "nestjs-zendesk": "11.0.0"
-  },
-  "devDependencies": {
-    "@nestjs/testing": "^11.1.28"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,9 +39,6 @@
         "nestjs-graphql-relay": "11.0.0",
         "nestjs-slack-webhook": "11.0.0",
         "nestjs-zendesk": "11.0.0"
-      },
-      "devDependencies": {
-        "@nestjs/testing": "^11.1.28"
       }
     },
     "example/node_modules/@angular-devkit/core": {
@@ -15061,9 +15058,6 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
-      },
-      "devDependencies": {
-        "@nestjs/testing": "^11.1.28"
       },
       "peerDependencies": {
         "node-zendesk": "^6.0.1"

--- a/packages/nestjs-zendesk/package.json
+++ b/packages/nestjs-zendesk/package.json
@@ -27,8 +27,5 @@
   },
   "peerDependencies": {
     "node-zendesk": "^6.0.1"
-  },
-  "devDependencies": {
-    "@nestjs/testing": "^11.1.28"
   }
 }


### PR DESCRIPTION
## Summary

- Remove duplicate @nestjs/testing dev dependency declarations from the example workspace and nestjs-zendesk.
- Keep @nestjs/testing centralized in the root workspace.
- Refresh the lockfile without changing the installed testing version.

## Verification

- npm ci --ignore-scripts
- npm run clean --workspaces && npm run build --workspaces
- npm run lint --workspaces
- SLACK_WEBHOOK_URL=https://example.com npm test -- --runInBand (26 suites, 42 tests)
- npm pack --dry-run --workspace nestjs-zendesk

No domain logic or public API behavior is changed.
