### PR TITLE
test(firebase): remove jest-mock-extended dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@jest/globals": "^30.4.1",
         "@nestjs/testing": "^11.1.28",
         "dotenv-cli": "^11.0.0",
-        "jest-mock-extended": "^4.0.1",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.12"
       },
@@ -9634,22 +9633,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-mock-extended": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-4.0.1.tgz",
-      "integrity": "sha512-Q/4k/yefiv/Al3n755V9xDEwMiL+7LwkjRKjaORkgCdovZv00hF/D0QypLoqO+MVfrYkzCYa4BYlcEKA74iOgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.isequal": "^4.5.0",
-        "ts-essentials": "^10.1.1"
-      },
-      "peerDependencies": {
-        "@jest/globals": "^28.0.0 || ^29.0.0 || ^30.0.0",
-        "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0 || ^30.0.0",
-        "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
-      }
-    },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -10353,14 +10336,6 @@
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
@@ -13792,21 +13767,6 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/ts-essentials": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.1.1.tgz",
-      "integrity": "sha512-4aTB7KLHKmUvkjNj8V+EdnmuVTiECzn3K+zIbRthumvHu+j44x3w63xpfs0JL3NGIzGXqoQ7AV591xHO+XrOTw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=4.5.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
     },
     "node_modules/ts-graphviz": {
       "version": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@jest/globals": "^30.4.1",
     "@nestjs/testing": "^11.1.28",
     "dotenv-cli": "^11.0.0",
-    "jest-mock-extended": "^4.0.1",
     "rimraf": "^6.1.3",
     "ts-jest": "^29.4.12"
   },

--- a/packages/nestjs-firebase/src/firebase.module.spec.ts
+++ b/packages/nestjs-firebase/src/firebase.module.spec.ts
@@ -2,7 +2,6 @@ import * as path from "node:path";
 import { describe, expect, it, jest } from "@jest/globals";
 import { Test } from "@nestjs/testing";
 import * as admin from "firebase-admin";
-import { mock } from "jest-mock-extended";
 import { FirebaseConstants } from "./firebase.constants";
 import {
   FirebaseAdmin,
@@ -12,7 +11,16 @@ import {
 import { FirebaseModule } from "./firebase.module";
 
 describe("FirebaseModule", () => {
-  jest.spyOn(admin, "initializeApp").mockReturnValue(mock<admin.app.App>());
+  const firebaseApp = {
+    auth: jest.fn(() => ({}) as admin.auth.Auth),
+    database: jest.fn(() => ({}) as admin.database.Database),
+    firestore: jest.fn(() => ({}) as admin.firestore.Firestore),
+    messaging: jest.fn(() => ({}) as admin.messaging.Messaging),
+    remoteConfig: jest.fn(() => ({}) as admin.remoteConfig.RemoteConfig),
+    storage: jest.fn(() => ({}) as admin.storage.Storage),
+  } as unknown as admin.app.App;
+
+  jest.spyOn(admin, "initializeApp").mockReturnValue(firebaseApp);
 
   const googleApplicationCredential = path.join(
     __dirname,


### PR DESCRIPTION
## Summary
- replace `jest-mock-extended` with a small Firebase app fake using Jest built-ins
- remove `jest-mock-extended` and its dedicated transitive dependencies from the lockfile
- keep production and domain logic unchanged

## Verification
- `npm run build --workspaces`
- `npm run lint --workspaces`
- `SLACK_WEBHOOK_URL=https://example.com npm test -- --runInBand` (26 suites, 42 tests)
- `npm pack --workspaces --dry-run --cache /private/tmp/nestjs-plugins-npm-cache`
- `git diff --check`