### PR TITLE
fix(ci): restore Codecov coverage upload

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,3 +30,7 @@ jobs:
           CI: true
       - name: Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          disable_search: true
+          fail_ci_if_error: true
+          files: ./coverage.lcov

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -34,3 +34,4 @@ jobs:
           disable_search: true
           fail_ci_if_error: true
           files: ./coverage.lcov
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "npm run clean --workspaces",
     "lint": "npm run lint --workspaces",
     "rebuild:test-native": "npm rebuild sqlite3 --ignore-scripts=false",
-    "test": "npm run rebuild:test-native && node --import tsx --env-file-if-exists=example/.env.test --test --experimental-test-coverage --test-coverage-include=\"packages/*/src/*.ts\" --test-coverage-exclude=\"packages/**/*.spec.ts\" --test-coverage-exclude=\"packages/**/*.test.ts\" \"packages/**/*.spec.ts\" \"packages/**/*.test.ts\" \"example/**/*-spec.ts\" \"example/**/*.spec.ts\""
+    "test": "npm run rebuild:test-native && node --import tsx --env-file-if-exists=example/.env.test --test --experimental-test-coverage --test-coverage-include=\"packages/*/src/*.ts\" --test-coverage-exclude=\"packages/**/*.spec.ts\" --test-coverage-exclude=\"packages/**/*.test.ts\" --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage.lcov \"packages/**/*.spec.ts\" \"packages/**/*.test.ts\" \"example/**/*-spec.ts\" \"example/**/*.spec.ts\""
   },
   "devDependencies": {
     "@as-integrations/fastify": "^3.1.0",


### PR DESCRIPTION
## Summary

- generate `coverage.lcov` with Node.js's built-in LCOV test reporter
- upload the explicit report file to Codecov
- fail CI when the coverage report is missing or the upload fails

No additional development dependency is required.

## Verification

- `SLACK_WEBHOOK_URL=https://example.com npm test` (27 tests passed)
- confirmed `coverage.lcov` contains 22 TypeScript source records
- `npm run lint`
- `npx biome check .`
- `actionlint .github/workflows/nodejs.yml`
- `git diff --check`
