### PR TITLE
fix(ci): track Codecov bundles by package

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,7 +24,13 @@ jobs:
       - run: npm ci
       - run: npm run build
       - name: Codecov Bundle Analysis
-        run: npx @codecov/bundle-analyzer example/dist --bundle-name=nestjs-plugins-example --upload-token="$CODECOV_TOKEN" --ignore-patterns '**/*.map' '**/*.d.ts' '**/*.spec.js'
+        run: |
+          for package_dir in packages/*; do
+            npx @codecov/bundle-analyzer "$package_dir/lib" \
+              --bundle-name="${package_dir##*/}" \
+              --upload-token="$CODECOV_TOKEN" \
+              --ignore-patterns '**/*.map' '**/*.d.ts' '**/*.spec.js'
+          done
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - run: npm run lint


### PR DESCRIPTION
## Summary
- analyze each published package's `lib` output instead of the NestJS example app
- upload separate Codecov bundles named `nestjs-firebase`, `nestjs-graphql-relay`, `nestjs-slack-webhook`, and `nestjs-zendesk`
- keep Test Analytics as a single JUnit upload because test case paths retain package attribution

## Verification
- ran Bundle Analyzer dry-run successfully for all four package outputs
- `actionlint .github/workflows/nodejs.yml`
- `git diff --check`